### PR TITLE
Lens patches1

### DIFF
--- a/lenulf.asd
+++ b/lenulf.asd
@@ -14,5 +14,8 @@
                (:file "preprocessing-rules")   
                (:file "stem")
                (:file "tt")
-               (:file "postprocess-ulf-tree")))
+               (:file "postprocess-ulf-tree"))
+  :around-compile (lambda (next)
+                    (proclaim '(optimize (debug 2) (safety 3) (space 1) (speed 1)))
+                    (funcall next)))
 

--- a/parse-tree-to-ulf.lisp
+++ b/parse-tree-to-ulf.lisp
@@ -90,11 +90,15 @@
 ;`````````````````````````````````
   (cond ((null tree) nil); to allow empty cdr upon recursion
         ((atom tree); unexpected
-         (format t "~%** Invalid input ~a to 'parse-tee-to-raw-ulf'" tree))
-        ((and (listp (car tree)) (null (cdr tree))); double bracketing?
+         (format t "~%** Invalid input ~a to 'parse-tree-to-raw-ulf'" tree))
+        ((and (listp (car tree)) (null (cdr tree))); double bracketing (Brown)?
          (parse-tree-to-raw-ulf (car tree))); drop the outer brackets
-        ((simple-tree tree) 
+        ((and (eq (car tree) 'S1) (null (cddr tree))); (S1 (...)) (BLLIP)?
+         (parse-tree-to-raw-ulf (second tree))); drop the (S1 (...)) wrapper
+        ((simple-tree tree)
          (simple-tree-to-raw-ulf tree)); e.g., (AUX (VBD were))
+        ((eq (car tree) 'MD) ; BLLIP fails to wrap (AUX ...) around modals
+         (pos+word-to-raw-ulf (list (aux-inflection 'MD (cadr tree)) (cadr tree))))
         ((pos+word tree) (pos+word-to-raw-ulf tree)); e.g., (NN safety)
         (t (if (atom (car tree)); drop initial atom (nonterminal category)
                                 ; and "recurse downwand" on (cdr tree)

--- a/tt.lisp
+++ b/tt.lisp
@@ -72,6 +72,7 @@
             ((integerp index) (nth (- index 1) expr))
             (t (setq ii (format nil "(~a)" index)); prepare for reading as a list
                (setq ii (substitute #\Space #\. ii)); blanks instead of dots
+               (setq ii (remove #\| ii))
                (setq ii (read-from-string ii)); now we have a list of indices
                (setq result expr)
                (dolist (i ii)
@@ -488,6 +489,7 @@
          ((and (atom i) 
                (setq ii (format nil "(~s)" i)); prepare for reading as a list
                (setq ii (substitute #\Space #\. ii)); blanks instead of dots
+               (setq ii (remove #\| ii))
                (setq ii (read-from-string ii)); now we have a list of indices
                (not (find-if-not #'integerp ii))) t)
          (t nil))


### PR DESCRIPTION
Patches from Len to fix the modal auxiliary suffixing for the BLLIP parser and the SBCL bug for indexing of passives.