### PR TITLE
Quote handling

### DIFF
--- a/parse-more.lisp
+++ b/parse-more.lisp
@@ -25,7 +25,8 @@
       (setf *k&k-setup-complete* t)
       (format t "Done!~%"))
     (lispify-parser-output
-      (py4cl:python-eval (format nil "str(benepar_parser.parse(\"~a\"))" str))))
+      (py4cl:python-eval (format nil "str(benepar_parser.parse(\"~a\"))"
+                                 (escape-chars str '(#\"))))))
 
 (defun parse-km (str)
 ;; Calls the pretrained K&K parser for K&M through python. This is slightly
@@ -55,7 +56,8 @@
       (format t "Done!~%"))
 
     ;; Parse sentence.
-    (py4cl:python-exec (format nil "tokens = word_tokenize(\"~a\")" str))
+    (py4cl:python-exec (format nil "tokens = word_tokenize(\"~a\")"
+                               (escape-chars str '(#\"))))
     (py4cl:python-exec "predicted, _ = parser.parse([('UNK', token) for token in tokens])")
     (let ((pyout (py4cl:python-eval "predicted.convert().linearize()"))
           (mid-file (format nil "~a.txt" (gensym)))

--- a/parser/english-to-ulf.lisp
+++ b/parser/english-to-ulf.lisp
@@ -51,7 +51,7 @@
   ;   (if *show-stages*
   ;       (format t "~%~% (Possibly) adjusted input string: ~%   ~s~%~%"
   ;                 str))
-      (setq parse-tree (parse (escape-string str) :parser parser)); Charniak parse
+      (setq parse-tree (parse (escape-chars str '(#\,)) :parser parser)); Charniak parse
        ; which handles multi-sentence strings (with {. ! ?} punctuation)
       (if (unpunctuated-wh-question parse-tree)
           (setq parse-tree (parse (concatenate 'string str "?"))))
@@ -105,13 +105,13 @@
  (and (listp xx) (= (length xx) 2) (atom (car xx)) (atom (second xx))
  )); end of pair-of-atoms
 
-(defun escape-string (str)
-  "Escapes characters that affect reading into s-expressions."
+(defun escape-chars (str chars)
+  "Escapes given characters."
   (let ((escaped-list
           (reduce #'(lambda (acc cur)
-                      (case cur
-                        ((#\" #\,) (cons cur (cons #\\ acc)))
-                        (otherwise (cons cur acc))))
+                      (cond
+                        ((member cur chars) (cons cur (cons #\\ acc)))
+                        (t (cons cur acc))))
               (coerce str 'list)
               :initial-value nil)))
     (coerce (reverse escaped-list) 'string)))

--- a/parser/english-to-ulf.lisp
+++ b/parser/english-to-ulf.lisp
@@ -51,7 +51,7 @@
   ;   (if *show-stages*
   ;       (format t "~%~% (Possibly) adjusted input string: ~%   ~s~%~%"
   ;                 str))
-      (setq parse-tree (parse str :parser parser)); Charniak parse
+      (setq parse-tree (parse (escape-string str) :parser parser)); Charniak parse
        ; which handles multi-sentence strings (with {. ! ?} punctuation)
       (if (unpunctuated-wh-question parse-tree)
           (setq parse-tree (parse (concatenate 'string str "?"))))
@@ -104,4 +104,15 @@
 ;~~~~~~~~~~~~~~~~~~~~~~~
  (and (listp xx) (= (length xx) 2) (atom (car xx)) (atom (second xx))
  )); end of pair-of-atoms
+
+(defun escape-string (str)
+  "Escapes characters that affect reading into s-expressions."
+  (let ((escaped-list
+          (reduce #'(lambda (acc cur)
+                      (case cur
+                        ((#\" #\,) (cons cur (cons #\\ acc)))
+                        (otherwise (cons cur acc))))
+              (coerce str 'list)
+              :initial-value nil)))
+    (coerce (reverse escaped-list) 'string)))
 


### PR DESCRIPTION
Escapes commas before parsing. Additionally, double quotes are escaped for the python-based parsers.